### PR TITLE
Fix question parsing logic

### DIFF
--- a/src/flows/answer_flow.py
+++ b/src/flows/answer_flow.py
@@ -21,12 +21,16 @@ class AnswerFlow:
 
     @staticmethod
     def _sanitize_question_text(text: str) -> str:
-        """移除包含答案的行"""
+        """移除包含解答或說明標題的行"""
         if not text:
             return text
+
+        import re
+
+        pattern = re.compile(r"^\s*(答案|解答|參考答案|建議|說明|解析)[\s:：]", re.I)
         lines = []
         for line in text.splitlines():
-            if any(k in line for k in ["答案", "解答", "參考答案", "建議"]):
+            if pattern.match(line):
                 continue
             lines.append(line)
         return "\n".join(lines).strip()

--- a/src/flows/content_flow.py
+++ b/src/flows/content_flow.py
@@ -16,12 +16,16 @@ class ContentFlow:
 
     @staticmethod
     def _sanitize_question_text(text: str) -> str:
-        """移除可能包含答案提示的行"""
+        """移除可能包含解答或說明標題的行"""
         if not text:
             return text
+
+        import re
+
+        pattern = re.compile(r"^\s*(答案|解答|參考答案|建議|說明|解析)[\s:：]", re.I)
         lines = []
         for line in text.splitlines():
-            if any(k in line for k in ["答案", "解答", "參考答案", "建議"]):
+            if pattern.match(line):
                 continue
             lines.append(line)
         return "\n".join(lines).strip()


### PR DESCRIPTION
## Summary
- ensure question sanitizer only strips obvious answer or explanation headers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b30f222e08328b4270fa6b0148498