### PR TITLE
Improve markdown handling and answer sources

### DIFF
--- a/src/flows/answer_flow.py
+++ b/src/flows/answer_flow.py
@@ -88,6 +88,7 @@ class AnswerFlow:
             result = self._store_question_data(
                 question_text=question_text,
                 answer_text=answer_data['answer'],
+                answer_sources=answer_data.get('sources', []),
                 subject=subject,
                 knowledge_points=knowledge_points
             )
@@ -121,7 +122,7 @@ class AnswerFlow:
                 'type': 'question'
             }
 
-    def _store_question_data(self, question_text: str, answer_text: str, subject: str, knowledge_points: List[str]) -> Dict[str, Any]:
+    def _store_question_data(self, question_text: str, answer_text: str, answer_sources: list, subject: str, knowledge_points: List[str]) -> Dict[str, Any]:
         """
         儲存單一問題及其關聯的知識點
         """
@@ -137,10 +138,13 @@ class AnswerFlow:
         )
 
         # 儲存問題
+        import json
+
         question_id = self.db.add_question(
             document_id=doc_id,
             question_text=format_code_blocks(question_text),
             answer_text=format_code_blocks(format_answer_text(answer_text)),
+            answer_sources=json.dumps(answer_sources, ensure_ascii=False),
             subject=subject
         )
 

--- a/src/utils/file_processor.py
+++ b/src/utils/file_processor.py
@@ -133,7 +133,7 @@ class FileProcessor:
 
         cleaned_lines = []
         for line in text.splitlines():
-            line = line.replace('\u3000', ' ').replace('\xa0', ' ')
+            line = line.replace('\u3000', '  ').replace('\xa0', ' ')
             line = line.replace('←', '<-').replace('→', '->')
 
             # 移除私用區與控制字元，避免截斷或異常符號


### PR DESCRIPTION
## Summary
- detect and fence indented pseudo code blocks before formatting
- preserve full-width leading spaces in preprocessing
- sanitize question text with new detection helper
- store `sources` for exam and study questions
- persist sources for individual question flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c24f028f88328a9616e3c2b411212