### PR TITLE
Fix source display and preserve code blocks

### DIFF
--- a/src/core/database.py
+++ b/src/core/database.py
@@ -118,6 +118,13 @@ class DatabaseManager:
             # 欄位已存在，忽略錯誤
             pass
 
+        # 為現有表新增 answer_sources 欄位（如果不存在）
+        try:
+            cur.execute('ALTER TABLE questions ADD COLUMN answer_sources TEXT')
+            self.conn.commit()
+        except sqlite3.OperationalError:
+            pass
+
         # 為現有表新增 difficulty 欄位（如果不存在）
         try:
             cur.execute('ALTER TABLE questions ADD COLUMN difficulty TEXT')
@@ -138,6 +145,13 @@ class DatabaseManager:
             self.conn.commit()
         except sqlite3.OperationalError:
             # 欄位已存在，忽略錯誤
+            pass
+
+        # 為現有表新增 source 欄位（如果不存在）
+        try:
+            cur.execute('ALTER TABLE documents ADD COLUMN source TEXT')
+            self.conn.commit()
+        except sqlite3.OperationalError:
             pass
         
         # 為現有表新增 key_points_summary 欄位（如果不存在）

--- a/src/core/gemini_client.py
+++ b/src/core/gemini_client.py
@@ -187,11 +187,14 @@ class GeminiClient:
         4.  **程式碼/虛擬碼格式**：如果答案包含程式碼或虛擬碼，請務必使用 Markdown 的 fenced code blocks (```) 包裹起來，並指定語言（如 ````python` 或 ````pseudocode`）。
         5.  **答案內容必須是純文字字串**：即使答案內容包含多個部分或結構化資訊，最終的 `answer` 欄位值也必須是一個單一的、格式化好的 Markdown 字串，而不是巢狀的 JSON 物件。
 
-        **請以嚴格的JSON格式回應：**
+        **請以嚴格的JSON格式回應，並在可能的情況下附上 2-3 筆參考來源：**
         ```json
-        {{
-            "answer": "（在這裡填寫你詳細、結構化的專業回答）"
-        }}
+        {
+            "answer": "（在這裡填寫你詳細、結構化的專業回答）",
+            "sources": [
+                {"title": "來源標題", "url": "https://example.com", "snippet": "簡短摘錄"}
+            ]
+        }
         ```
         """
         return await self._generate_with_json_parsing(prompt)


### PR DESCRIPTION
## Summary
- ensure DB migrations include `answer_sources` and `source`
- enrich Gemini answer prompt with references
- sanitize single-question text using consistent code detection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688c3cd51e7c8328a2a8d774b660d049