### PR TITLE
feat: allow creating notes from questions

### DIFF
--- a/src/notes/database.py
+++ b/src/notes/database.py
@@ -27,6 +27,10 @@ class UserNote(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     is_archived = Column(Integer, default=0)
+    # 新增欄位：來源題目資訊
+    source_question_id = Column(String(36))
+    source_question_text = Column(Text)
+    source_answer_text = Column(Text)
 
     user = relationship("User")
     categories = relationship("NoteCategory", secondary="note_category_links", back_populates="notes")
@@ -126,7 +130,10 @@ class NotesDatabaseManager:
                 tags=json.dumps(kwargs.get('tags', []), ensure_ascii=False),
                 ai_summary=kwargs.get('ai_summary'),
                 ai_keywords=json.dumps(kwargs.get('ai_keywords', []), ensure_ascii=False),
-                is_archived=kwargs.get('is_archived', 0)
+                is_archived=kwargs.get('is_archived', 0),
+                source_question_id=kwargs.get('source_question_id'),
+                source_question_text=kwargs.get('source_question_text'),
+                source_answer_text=kwargs.get('source_answer_text')
             )
             session.add(note)
             session.flush()
@@ -543,7 +550,10 @@ class NotesDatabaseManager:
             "ai_keywords": json.loads(note.ai_keywords) if note.ai_keywords else [],
             "created_at": note.created_at.isoformat(),
             "updated_at": note.updated_at.isoformat(),
-            "is_archived": bool(note.is_archived)
+            "is_archived": bool(note.is_archived),
+            "source_question_id": note.source_question_id,
+            "source_question_text": note.source_question_text,
+            "source_answer_text": note.source_answer_text
         }
 
     def _category_to_dict(self, category: NoteCategory) -> Dict[str, Any]:

--- a/src/notes/note_manager.py
+++ b/src/notes/note_manager.py
@@ -24,6 +24,9 @@ class NoteManager:
             'content': content,
             'content_type': kwargs.get('content_type', 'markdown'),
             'tags': kwargs.get('custom_tags', []),
+            'source_question_id': kwargs.get('source_question_id'),
+            'source_question_text': kwargs.get('source_question_text'),
+            'source_answer_text': kwargs.get('source_answer_text')
         }
 
         # 如果啟用 AI 分析，則執行分析
@@ -83,6 +86,16 @@ class NoteManager:
             'ai_keywords': ai_keywords,
             'has_ai_analysis': bool(note.get('ai_summary') or ai_keywords)
         }
+
+        # 來源題目資訊
+        if note.get('source_question_id'):
+            note_details['source_question'] = {
+                'id': note.get('source_question_id'),
+                'text': note.get('source_question_text'),
+                'answer': note.get('source_answer_text')
+            }
+        else:
+            note_details['source_question'] = None
 
         # 只有當筆記啟用了 AI 分析時，才生成智慧建議
         if note_details['has_ai_analysis']:
@@ -393,14 +406,22 @@ class NoteManager:
 
     # === 從題庫/教材生成筆記 ===
 
-    def create_note_from_questions(self, user_id: int, questions_data: List[Dict], title: str = None) -> Optional[str]:
+    def create_note_from_questions(
+        self,
+        user_id: int,
+        questions_data: List[Dict],
+        title: str = None,
+        source_question_id: str = None,
+        source_question_text: str = None,
+        source_answer_text: str = None
+    ) -> Optional[str]:
         """從題庫資料生成筆記"""
         try:
             ai_result = self.ai_client.generate_note_from_questions(questions_data)
-            
+
             note_title = title or ai_result.get('title', '從題庫生成的筆記')
             note_content = ai_result.get('content', '')
-            
+
             # 創建筆記
             note_id = self.db_manager.create_note(
                 user_id=user_id,
@@ -409,7 +430,10 @@ class NoteManager:
                 content_type='markdown',
                 tags=json.dumps(ai_result.get('suggested_tags', []), ensure_ascii=False),
                 ai_summary=ai_result.get('study_tips'),
-                ai_keywords=json.dumps(ai_result.get('key_concepts', []), ensure_ascii=False)
+                ai_keywords=json.dumps(ai_result.get('key_concepts', []), ensure_ascii=False),
+                source_question_id=source_question_id,
+                source_question_text=source_question_text,
+                source_answer_text=source_answer_text
             )
             
             if note_id:

--- a/src/webapp/notes_blueprint.py
+++ b/src/webapp/notes_blueprint.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, g, jsonify
 from ..notes.note_manager import NoteManager
 from ..webapp.auth_middleware import require_admin
+from ..core.database import DatabaseManager
 
 # Define the blueprint for the notes system
 notes_bp = Blueprint(
@@ -89,6 +90,86 @@ def create_note():
             flash("建立筆記時發生錯誤。", "danger")
 
     return render_template('notes/note_edit.html', title="新增筆記", note=None)
+
+
+@notes_bp.route('/from-question/<string:question_id>', methods=['GET', 'POST'])
+def create_note_from_question(question_id):
+    """Create a note based on a question from the question bank."""
+    user_id = g.current_user['id']
+    main_db = DatabaseManager()
+    question = main_db.get_question_by_id(question_id)
+    if not question:
+        flash("找不到指定的題目。", "danger")
+        return redirect(url_for('questions'))
+    source_question = {
+        'id': question['id'],
+        'text': question['question_text'],
+        'answer': question.get('answer_text')
+    }
+    if request.method == 'POST':
+        # AI 自動生成
+        if 'ai_generate' in request.form:
+            note_id = note_manager.create_note_from_questions(
+                user_id=user_id,
+                questions_data=[{
+                    'question_text': source_question['text'],
+                    'answer_text': source_question['answer']
+                }],
+                source_question_id=question_id,
+                source_question_text=source_question['text'],
+                source_answer_text=source_question['answer']
+            )
+            if note_id:
+                flash("筆記已由 AI 自動生成！", "success")
+                return redirect(url_for('.note_detail', note_id=note_id))
+            flash("AI 生成筆記失敗。", "danger")
+        else:
+            title = request.form.get('title')
+            content = request.form.get('content')
+            enable_ai_analysis = request.form.get('enable_ai_analysis') == 'on'
+            enable_ai_organization = request.form.get('enable_ai_organization') == 'on'
+            organization_types = request.form.getlist('organization_types')
+            if not title or not content:
+                flash("標題和內容不能為空。", "danger")
+            else:
+                note_id = note_manager.create_new_note(
+                    user_id,
+                    title,
+                    content,
+                    enable_ai_analysis=enable_ai_analysis,
+                    source_question_id=question_id,
+                    source_question_text=source_question['text'],
+                    source_answer_text=source_question['answer']
+                )
+                if note_id:
+                    if enable_ai_organization and organization_types:
+                        from threading import Thread
+
+                        def generate_organizations():
+                            for org_type in organization_types:
+                                try:
+                                    note_manager.organize_note_with_ai(user_id, note_id, org_type)
+                                except Exception as e:
+                                    print(f"Warning: Failed to generate {org_type} organization: {e}")
+
+                        thread = Thread(target=generate_organizations)
+                        thread.daemon = True
+                        thread.start()
+
+                        flash(f"筆記已成功建立！{len(organization_types)} 種整理方式正在背景生成中...", "success")
+                    else:
+                        flash("筆記已成功建立！", "success")
+                    return redirect(url_for('.note_detail', note_id=note_id))
+                flash("建立筆記時發生錯誤。", "danger")
+
+    default_title = f"筆記：{source_question['text'][:30]}..." if source_question else "新增筆記"
+    return render_template(
+        'notes/note_edit.html',
+        title="新增筆記",
+        note=None,
+        default_title=default_title,
+        source_question=source_question
+    )
 
 @notes_bp.route('/<string:note_id>')
 def note_detail(note_id):

--- a/src/webapp/templates/notes/note_detail.html
+++ b/src/webapp/templates/notes/note_detail.html
@@ -25,6 +25,29 @@
         </div>
     </div>
 
+    {% if note.source_question %}
+    <div class="mb-3">
+        <a href="{{ url_for('question_detail', q_id=note.source_question.id) }}" class="btn btn-outline-secondary btn-sm">返回原始題目</a>
+        <div class="accordion mt-2" id="sourceQuestionAccordion">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingSource">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSource" aria-expanded="false" aria-controls="collapseSource">
+                        顯示/隱藏來源題目
+                    </button>
+                </h2>
+                <div id="collapseSource" class="accordion-collapse collapse" aria-labelledby="headingSource" data-bs-parent="#sourceQuestionAccordion">
+                    <div class="accordion-body">
+                        <h6 class="fw-bold">題目</h6>
+                        <p>{{ note.source_question.text }}</p>
+                        <h6 class="fw-bold">答案</h6>
+                        <p>{{ note.source_question.answer }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
     <div class="row">
         <!-- Main Note Content -->
         <div class="col-lg-8">

--- a/src/webapp/templates/notes/note_edit.html
+++ b/src/webapp/templates/notes/note_edit.html
@@ -16,9 +16,24 @@
     <div class="card shadow-sm">
         <div class="card-body">
             <form method="POST" action="">
+                {% if source_question %}
+                <div class="mb-3">
+                    <button class="btn btn-outline-info btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#source-question" aria-expanded="false" aria-controls="source-question">
+                        顯示/隱藏來源題目
+                    </button>
+                    <div class="collapse mt-2" id="source-question">
+                        <div class="card card-body">
+                            <h6 class="fw-bold">題目</h6>
+                            <p class="mb-3">{{ source_question.text }}</p>
+                            <h6 class="fw-bold">答案</h6>
+                            <p class="mb-0">{{ source_question.answer }}</p>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
                 <div class="mb-3">
                     <label for="title" class="form-label"><strong>標題</strong></label>
-                    <input type="text" class="form-control" id="title" name="title" value="{{ note.title if note else '' }}" required>
+                    <input type="text" class="form-control" id="title" name="title" value="{{ note.title if note else (default_title if default_title is defined else '') }}" required>
                 </div>
 
                 <div class="mb-3">
@@ -154,6 +169,11 @@
                 <button type="submit" class="btn btn-primary">
                     <i class="fas fa-save me-1"></i> 儲存筆記
                 </button>
+                {% if source_question %}
+                <button type="submit" name="ai_generate" class="btn btn-outline-success ms-2">
+                    🚀 AI 自動生成筆記
+                </button>
+                {% endif %}
             </form>
         </div>
     </div>

--- a/src/webapp/templates/question_detail.html
+++ b/src/webapp/templates/question_detail.html
@@ -14,6 +14,7 @@
                     {% if question.subject %}
                     <a href="/questions?subject={{ question.subject }}" class="btn btn-outline-primary btn-sm">查看同科目</a>
                     {% endif %}
+                    <a href="{{ url_for('notes.create_note_from_question', question_id=question.id) }}" class="btn btn-outline-warning btn-sm">✍️ 為此題建立筆記</a>
                 </div>
             </div>
             <div class="card-body">

--- a/src/webapp/templates/questions.html
+++ b/src/webapp/templates/questions.html
@@ -107,6 +107,7 @@
                                 <td>
                                     <div class="btn-group" role="group">
                                         <a href="/question/{{ q.id }}" class="btn btn-outline-primary btn-sm">查看</a>
+                                        <a href="{{ url_for('notes.create_note_from_question', question_id=q.id) }}" class="btn btn-outline-warning btn-sm">✍️ 加入筆記</a>
                                         {% if g.current_user and g.current_user.role == 'admin' %}
                                         <a href="/edit_question/{{ q.id }}" class="btn btn-outline-secondary btn-sm">編輯</a>
                                         {% endif %}


### PR DESCRIPTION
## Summary
- enable note creation from question bank entries
- show source question metadata on note edit and detail pages
- add UI buttons linking questions to note creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890b0590b688328bcc63538ae325f66